### PR TITLE
Use existing nyc config inside package.json

### DIFF
--- a/bin/cov8.js
+++ b/bin/cov8.js
@@ -11,6 +11,7 @@ const path = require('path')
 
 yargs // eslint-disable-line
   .usage('$0 [opts] <script> [opts]')
+  .pkgConf('nyc')
   .option('exclude', {
     alias: 'x',
     default: exclude.defaultExclude,


### PR DESCRIPTION
This makes it easy to share include/exclude rules between the two.

The next thing would be to output directly to .nyc_output in order for `nyc report` to work. But that's for another day.